### PR TITLE
Add root npm scripts for frontend build and functions install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ npm run dev
 
 ### Backend functions
 
-Install the Netlify CLI if you haven't already and start the development server which serves both the frontend and the functions. Make sure dependencies are installed in `netlify/` so the SQLite driver is available:
+Install the Netlify CLI if you haven't already and start the development server which serves both the frontend and the functions. Install the backend dependencies using the root npm script so the SQLite driver is available:
 
 ```bash
 npm install -g netlify-cli # optional if already installed
-cd netlify && npm install
+npm run install:functions
 netlify dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "todo-root",
+  "private": true,
+  "scripts": {
+    "build": "cd frontend && npm run build",
+    "install:functions": "npm --prefix netlify install"
+  }
+}


### PR DESCRIPTION
## Summary
- add a root `package.json` with build and install scripts
- document the new install step for backend functions in the README

## Testing
- `npm run lint` *(fails: Cannot find module 'react')*