### PR TITLE
Fix Netlify publish path

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ npm run dev
 
 ### Backend functions
 
-Install the Netlify CLI if you haven't already and start the development server which serves both the frontend and the functions. Make sure dependencies are installed in `netlify/` so the SQLite driver is available:
+Install the Netlify CLI if you haven't already and start the development server which serves both the frontend and the functions. Install the backend dependencies using the root npm script so the SQLite driver is available:
 
 ```bash
 npm install -g netlify-cli # optional if already installed
-cd netlify && npm install
+npm run install:functions
 netlify dev
 ```
 
@@ -30,7 +30,7 @@ Requests to `/api/*` will be proxied to the function defined in `netlify/functio
 
 1. Commit the included `netlify.toml` configuration.
 2. Create a new site in the Netlify dashboard from this repository.
-3. Netlify will run `npm run build` in `frontend/` and publish the contents of `frontend/dist`.
+3. Netlify will run `npm run build` and publish the contents of `frontend/dist`.
 4. API calls from the frontend to `/api/*` will run the Netlify Functions backend.
 
 ## Testing

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,4 @@
 [build]
-  base = "frontend"
   command = "npm run build"
   publish = "frontend/dist"
   functions = "netlify/functions"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "todo-root",
+  "private": true,
+  "scripts": {
+    "build": "cd frontend && npm run build",
+    "install:functions": "npm --prefix netlify install"
+  }
+}


### PR DESCRIPTION
## Summary
- remove `base` from `netlify.toml` so publish and functions paths resolve correctly
- clarify Netlify build step in the README

## Testing
- `cd frontend && npm run lint` *(fails: Cannot find module 'react')*
